### PR TITLE
Add filtering button for test failures

### DIFF
--- a/PlaygroundTester/Sources/PlaygroundTester/Interface/ResultsToggleButton.swift
+++ b/PlaygroundTester/Sources/PlaygroundTester/Interface/ResultsToggleButton.swift
@@ -1,0 +1,16 @@
+import SwiftUI
+
+struct ResultsToggleButton: View {
+  @Binding private(set) var isToggled: Bool
+  
+  var body: some View {
+    Button(action: {
+      isToggled.toggle()
+    }) {
+      let imageName = isToggled ? "xmark.octagon.fill" : "xmark.octagon"
+      let tintColor = isToggled ? Color.red : Color.gray
+      Image(systemName: imageName)
+        .tint(tintColor)
+    }
+  }
+}

--- a/PlaygroundTester/Sources/PlaygroundTester/Views/TestMethodsView.swift
+++ b/PlaygroundTester/Sources/PlaygroundTester/Views/TestMethodsView.swift
@@ -7,8 +7,11 @@ struct TestMethodsView: View {
   let methods: [ResultViewModel.Suite.Method]
   let title: String
 
+  @Binding private(set) var failuresOnly: Bool
+
   var body: some View {
-    List(methods) { method in
+    let results = failuresOnly ? methods.filter { $0.result.isSuccess == false } : methods
+    List(results) { method in
       if method.result.isSuccess {
         TestMethodView(name: method.name, result: method.result)
       } else {
@@ -19,6 +22,13 @@ struct TestMethodsView: View {
         }
       }
     }.navigationTitle(title)
+    .toolbar {
+      ToolbarItem(placement: .navigationBarTrailing) {
+        if results.isEmpty == false {
+          ResultsToggleButton(isToggled: $failuresOnly)
+        }
+      }
+    }
   }
 }
 

--- a/PlaygroundTester/Sources/PlaygroundTester/Views/TestSuitesView.swift
+++ b/PlaygroundTester/Sources/PlaygroundTester/Views/TestSuitesView.swift
@@ -7,17 +7,27 @@ struct TestSuitesView: View {
   let suites: [ResultViewModel.Suite]
   let title: String
 
+  @State private(set) var failuresOnly = false
+  
   var body: some View {
     NavigationView {
-      List(self.suites) { suite in
+      let results = failuresOnly ? suites.filter { $0.failures > 0 } : suites
+      List(results) { suite in
         NavigationLink {
-          TestMethodsView(methods: suite.methods, title: suite.name)
+          TestMethodsView(methods: suite.methods, title: suite.name, failuresOnly: $failuresOnly)
         } label: {
           TestSuiteView(name: suite.name, failedTests: suite.failures, passedTests: suite.successes)
         }
       }
       .navigationBarTitleDisplayMode(.inline)
       .navigationTitle(title)
+      .toolbar {
+        ToolbarItem(placement: .navigationBarTrailing) {
+          if results.isEmpty == false {
+            ResultsToggleButton(isToggled: $failuresOnly)
+          }
+        }
+      }
     }
   }
 }


### PR DESCRIPTION
I think it resolves https://github.com/Losiowaty/PlaygroundTester/issues/4?

The button is added as a bar button item, its state is replicated across both `TestSuitesView` and `TestMethodsView`.

### `TestSuitesView`
![Simulator Screen Shot - iPhone 12 - 2022-02-16 at 19 50 51](https://user-images.githubusercontent.com/5851058/154335914-de64451a-aa04-4ed6-a2d5-70a489e69161.png)
![Simulator Screen Shot - iPhone 12 - 2022-02-16 at 19 50 53](https://user-images.githubusercontent.com/5851058/154335920-2a810310-db20-4dcd-a1cd-2167159ebb35.png)

### `TestMethodsView`
![Simulator Screen Shot - iPhone 12 - 2022-02-16 at 19 51 13](https://user-images.githubusercontent.com/5851058/154335949-01a7acec-f38a-454e-b120-bd7da566a58a.png)
![Simulator Screen Shot - iPhone 12 - 2022-02-16 at 19 51 19](https://user-images.githubusercontent.com/5851058/154335956-055202d6-8f08-478f-8fc9-ff35238e1696.png)

Let me know if you need anything added/changed here. I tested it manually but it seems like it works, potentially we could add some snapshots with mock results but I didn't want to add another dependency so I'll leave it as is for now.

I can also grab https://github.com/Losiowaty/PlaygroundTester/issues/5 next if you'd like.