### PR TITLE
Manage test execution with flag

### DIFF
--- a/PlaygroundTester/Sources/PlaygroundTester/Interface/PlaygroundTesterView.swift
+++ b/PlaygroundTester/Sources/PlaygroundTester/Interface/PlaygroundTesterView.swift
@@ -5,7 +5,7 @@ public struct PlaygroundTesterView<Content: View>: View {
     
   private var isTesting: Bool {
     #if TESTING_ENABLED
-      return PlaygroundTesterConfigurator.isTesting
+      return PlaygroundTesterConfiguration.isTesting
     #else
       return false
     #endif
@@ -24,6 +24,6 @@ public struct PlaygroundTesterView<Content: View>: View {
   }
 }
 
-public enum PlaygroundTesterConfigurator {
+public enum PlaygroundTesterConfiguration {
   public static var isTesting = false
 }

--- a/PlaygroundTesterDemoApp/PlaygroundTesterDemoApp.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/PlaygroundTesterDemoApp/PlaygroundTesterDemoApp.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -5,9 +5,9 @@
         "package": "Difference",
         "repositoryURL": "https://github.com/krzysztofzablocki/Difference.git",
         "state": {
-          "branch": "master",
+          "branch": null,
           "revision": "02fe1111edc8318c4f8a0da96336fcbcc201f38b",
-          "version": null
+          "version": "1.0.1"
         }
       }
     ]

--- a/PlaygroundTesterDemoApp/PlaygroundTesterDemoApp.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/PlaygroundTesterDemoApp/PlaygroundTesterDemoApp.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -5,9 +5,9 @@
         "package": "Difference",
         "repositoryURL": "https://github.com/krzysztofzablocki/Difference.git",
         "state": {
-          "branch": null,
+          "branch": "master",
           "revision": "02fe1111edc8318c4f8a0da96336fcbcc201f38b",
-          "version": "1.0.1"
+          "version": null
         }
       }
     ]

--- a/PlaygroundTesterDemoApp/PlaygroundTesterDemoApp/PlaygroundTesterDemoAppApp.swift
+++ b/PlaygroundTesterDemoApp/PlaygroundTesterDemoApp/PlaygroundTesterDemoAppApp.swift
@@ -12,7 +12,7 @@ import PlaygroundTester
 struct PlaygroundTesterDemoAppApp: App {
     
     init() {
-        PlaygroundTester.PlaygroundTesterConfigurator.isTesting = true
+        PlaygroundTester.PlaygroundTesterConfiguration.isTesting = true
     }
     
     var body: some Scene {

--- a/README.md
+++ b/README.md
@@ -140,7 +140,7 @@ In your `App` object just do this :
 ```swift
 struct Myapp: App {
     init() {
-        PlaygroundTester.PlaygroundTesterConfigurator.isTesting = true
+        PlaygroundTester.PlaygroundTesterConfiguration.isTesting = true
     }
     var body: some Scene {
         WindowGroup {

--- a/README.md
+++ b/README.md
@@ -134,7 +134,7 @@ func testSampleExpectation() {
 At this moment unwaited expectations don't trigger an assertion failure.
 
 ### Runing tests
-In order to execute your tests you need to do one final thing : Set `isTesting` flag to `true` and prepare for `PlaygroundTesterView`.
+In order to execute your tests you need to do one final thing : Wrap your view in PlaygroundTesterView and set PlaygroundTester.PlaygroundTesterConfiguration.isTesting flag to true.
 In your `App` object just do this : 
 
 ```swift

--- a/README.md
+++ b/README.md
@@ -134,7 +134,7 @@ func testSampleExpectation() {
 At this moment unwaited expectations don't trigger an assertion failure.
 
 ### Runing tests
-In order to execute your tests you need to do one final thing : Wrap your view in PlaygroundTesterView and set PlaygroundTester.PlaygroundTesterConfiguration.isTesting flag to true.
+In order to execute your tests you need to do one final thing : Wrap your view in PlaygroundTesterWrapperView and set PlaygroundTester.PlaygroundTesterConfiguration.isTesting flag to true.
 In your `App` object just do this : 
 
 ```swift


### PR DESCRIPTION
Thank you for a very nice library.
I have a suggestion to make it more user friendly.

In many implementations, such as SDKs for advertising, the tests are managed by flags.
I think this implementation is more Swifty.

```.swift
@main
struct MyApp: App {
    
    init() {
        PlaygroundTesterConfigurator.isTesting = false
    }
    
    var body: some Scene {
        WindowGroup {
            PlaygroundTesterView {
                // your view
            }
        }
    }
}
```

If you don't mind, please adopt this idea.
Also, it would be helpful if you could revise my comments in the readme to be more appropriate.

If it's not desirable, I'll withdraw the Pull Request.